### PR TITLE
Build ZXing statically

### DIFF
--- a/0001-Search-for-Threads-Threads.patch
+++ b/0001-Search-for-Threads-Threads.patch
@@ -1,0 +1,27 @@
+From ad7a7cdbecb61e3e56f7b517311cc418c3b9d242 Mon Sep 17 00:00:00 2001
+From: Volker Krause <vkrause@kde.org>
+Date: Wed, 17 Jan 2024 17:56:28 +0100
+Subject: [PATCH] Search for Threads::Threads
+
+This is a workaround for linking to a static ZXing in Flatpaks (which is
+needed to work around the clash between "our" ZXing and the private on
+in the KDE Platform Flatpak).
+---
+ CMakeLists.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 782d9543..1423e5ac 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -66,6 +66,7 @@ set_package_properties("PhoneNumber" PROPERTIES PURPOSE "Parsing and geo-coding
+ find_package(OpenSSL 1.1 REQUIRED COMPONENTS Crypto)
+ find_package(OsmTools)
+ set_package_properties(OsmTools PROPERTIES TYPE OPTIONAL PURPOSE "Needed only for regenereating the airport database (ie. you most likely don't need this)")
++find_package(Threads) # workaround for static ZXing in Flatpak (not needed with Qt6 anymore)
+ 
+ if (NOT ANDROID)
+     set_package_properties(KF${KF_MAJOR_VERSION}CalendarCore PROPERTIES TYPE REQUIRED)
+-- 
+2.42.0
+

--- a/org.kde.itinerary.json
+++ b/org.kde.itinerary.json
@@ -141,7 +141,7 @@
             "name": "zxing",
             "config-opts": [
                 "-DBUILD_DEPENDENCIES=LOCAL",
-                "-DBUILD_SHARED_LIBS=ON",
+                "-DBUILD_SHARED_LIBS=OFF",
                 "-DBUILD_UNIT_TESTS=OFF",
                 "-DBUILD_BLACKBOX_TESTS=OFF",
                 "-DBUILD_EXAMPLES=OFF"
@@ -181,6 +181,10 @@
                         "stable-only": true,
                         "url-template": "https://download.kde.org/stable/release-service/$version/src/kitinerary-$version.tar.xz"
                     }
+                },
+                {
+                    "type": "patch",
+                    "path": "0001-Search-for-Threads-Threads.patch"
                 }
             ],
             "cleanup": [


### PR DESCRIPTION
Currently the ZXing build here is overriding the internal one of the platform with an ABI-incompatible version, resulting in the application to not even start.