### PR TITLE
KDE KF6 update

### DIFF
--- a/org.kde.itinerary.json
+++ b/org.kde.itinerary.json
@@ -1,7 +1,7 @@
 {
     "id": "org.kde.itinerary",
     "runtime": "org.kde.Platform",
-    "runtime-version": "5.15-23.08",
+    "runtime-version": "6.6",
     "sdk": "org.kde.Sdk",
     "command": "itinerary",
     "finish-args": [
@@ -221,7 +221,8 @@
         {
             "name": "kopeninghours",
             "config-opts": [
-                "-DBUILD_TESTING=OFF"
+                "-DBUILD_TESTING=OFF",
+                "-DBUILD_WITH_QT6=ON"
             ],
             "buildsystem": "cmake-ninja",
             "builddir": true,
@@ -342,8 +343,8 @@
             ],
             "config-opts": [
                 "-DBUILD_TESTING=OFF",
-                "-DCMAKE_DISABLE_FIND_PACKAGE_KF5KIO=ON",
-                "-DCMAKE_DISABLE_FIND_PACKAGE_KF5FileMetaData=ON"
+                "-DCMAKE_DISABLE_FIND_PACKAGE_KF6KIO=ON",
+                "-DCMAKE_DISABLE_FIND_PACKAGE_KF6FileMetaData=ON"
             ],
             "cleanup": [
                 "/share/qlogging-categories5"

--- a/org.kde.itinerary.json
+++ b/org.kde.itinerary.json
@@ -33,8 +33,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://poppler.freedesktop.org/poppler-24.02.0.tar.xz",
-                    "sha256": "19187a3fdd05f33e7d604c4799c183de5ca0118640c88b370ddcf3136343222e",
+                    "url": "https://poppler.freedesktop.org/poppler-24.03.0.tar.xz",
+                    "sha256": "bafbf0db5713dec25b5d16eb2cd87e4a62351cdc40f050c3937cd8dd6882d446",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 3686,
@@ -63,8 +63,8 @@
                     "sources": [
                         {
                             "type": "archive",
-                            "url": "https://github.com/uclouvain/openjpeg/archive/v2.5.0.tar.gz",
-                            "sha256": "0333806d6adecc6f7a91243b2b839ff4d2053823634d4f6ed7a59bc87409122a",
+                            "url": "https://github.com/uclouvain/openjpeg/archive/v2.5.2.tar.gz",
+                            "sha256": "90e3896fed910c376aaf79cdd98bdfdaf98c6472efd8e1debf0a854938cbda6a",
                             "x-checker-data": {
                                 "type": "anitya",
                                 "project-id": 2550,
@@ -91,8 +91,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.kde.org/stable/release-service/23.08.5/src/kpkpass-23.08.5.tar.xz",
-                    "sha256": "d69e60bbb85aca3de1036735a17ef52abcd54470b21f1a97f45f7f40fc7cdab1",
+                    "url": "https://download.kde.org/stable/release-service/24.02.0/src/kpkpass-24.02.0.tar.xz",
+                    "sha256": "a2e3afe04cdab2fd7b2536d9b0ecf34036d274d2aa364de037cd5609fb3b08df",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 8763,
@@ -120,8 +120,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.kde.org/stable/release-service/23.08.5/src/kmime-23.08.5.tar.xz",
-                    "sha256": "b6894e733abf3a8fb4fc7de37b7cbf15cbebdc737b80f7fe632bdf61e5da3fda",
+                    "url": "https://download.kde.org/stable/release-service/24.02.0/src/kmime-24.02.0.tar.xz",
+                    "sha256": "4f1251484f18b6eedf62c9219a504e6357de5adff4016cc34a714dd0cb748065",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 8763,
@@ -173,8 +173,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.kde.org/stable/release-service/23.08.5/src/kitinerary-23.08.5.tar.xz",
-                    "sha256": "aebd2002fe8198cc95884af261882cce8fe0818ebcc34b1ce9a4715cf4e178a8",
+                    "url": "https://download.kde.org/stable/release-service/24.02.0/src/kitinerary-24.02.0.tar.xz",
+                    "sha256": "e18c62363607dd769092e9e15fce3e00250d706f78d1c7d8ad2835bc620d977a",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 8763,
@@ -201,8 +201,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.kde.org/stable/release-service/23.08.5/src/kpublictransport-23.08.5.tar.xz",
-                    "sha256": "e3f7e56e9e8b26310d26184e8b2a2b6f308c98cc98457181f4d5eabc0b255a58",
+                    "url": "https://download.kde.org/stable/release-service/24.02.0/src/kpublictransport-24.02.0.tar.xz",
+                    "sha256": "8addc5cde31ed54d9d18c7247aaefd669bde10a8cd76403784dd0bcff9cd22f8",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 8763,
@@ -228,8 +228,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.kde.org/stable/release-service/23.08.5/src/kopeninghours-23.08.5.tar.xz",
-                    "sha256": "262c4cf75e99c3989ce2150c467196ed0c5ae803d674e9372faa70d57d931946",
+                    "url": "https://download.kde.org/stable/release-service/24.02.0/src/kopeninghours-24.02.0.tar.xz",
+                    "sha256": "095a3cc15901fc41816add0cacb98da46435667ac24be18ec55f6fba05818477",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 8763,
@@ -255,8 +255,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.kde.org/stable/release-service/23.08.5/src/kosmindoormap-23.08.5.tar.xz",
-                    "sha256": "647bd4e37536502543494c8db8fcaa2f0a485c396920ee69e5238f367a48ab03",
+                    "url": "https://download.kde.org/stable/release-service/24.02.0/src/kosmindoormap-24.02.0.tar.xz",
+                    "sha256": "f8877e5d0e2f881b35e897b3d58e56b9ef23aecf1ea8be0cb2f4b01cb5d73634",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 8763,
@@ -309,8 +309,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.kde.org/stable/kirigami-addons/kirigami-addons-0.11.0.tar.xz",
-                    "sha256": "05296c5afbe6804308bf9c0d2751f3b748b40d00fa784946d1dcdf3af4bffbad",
+                    "url": "https://download.kde.org/stable/kirigami-addons/kirigami-addons-1.0.1.tar.xz",
+                    "sha256": "9d013847efb0048c6a2799ee0ed281b14eee15314ac20d7fba853197e45f29b7",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 242933,
@@ -330,8 +330,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.kde.org/stable/release-service/23.08.5/src/itinerary-23.08.5.tar.xz",
-                    "sha256": "42e38c9b0e147eb5223212470055c7dd3283ae7052c8537b565435a2889927a7",
+                    "url": "https://download.kde.org/stable/release-service/24.02.0/src/itinerary-24.02.0.tar.xz",
+                    "sha256": "6d63abc13fce4cd0804dbfc1c9b7c6595b833972758bd8d8207e1210a5e7c943",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 8763,

--- a/org.kde.itinerary.json
+++ b/org.kde.itinerary.json
@@ -283,13 +283,13 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.kde.org/stable/plasma-mobile/23.01.0/khealthcertificate-23.01.0.tar.xz",
-                    "sha256": "755dc2625c4b2ad06266ce19fa7565f87dc3df780d161830db498027477b6aa4",
+                    "url": "https://download.kde.org/stable/release-service/24.02.0/src/khealthcertificate-24.02.0.tar.xz",
+                    "sha256": "b038d3a6fd45ce6c19b80d29894d0ffe036f7cbaf8fcfcfd928a5fba2e6ba449",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 242958,
                         "stable-only": true,
-                        "url-template": "https://download.kde.org/stable/plasma-mobile/$version/khealthcertificate-$version.tar.xz"
+                        "url-template": "https://download.kde.org/stable/release-service/$version/src/khealthcertificate-$version.tar.xz"
                     }
                 }
             ],


### PR DESCRIPTION
Update v2.5.0.tar.gz to 2.5.2
Update poppler-24.02.0.tar.xz to 24.03.0
Update kpkpass-23.08.5.tar.xz to 24.02.0
Update kmime-23.08.5.tar.xz to 24.02.0
Update kitinerary-23.08.5.tar.xz to 24.02.0
Update kpublictransport-23.08.5.tar.xz to 24.02.0
Update kopeninghours-23.08.5.tar.xz to 24.02.0
Update kosmindoormap-23.08.5.tar.xz to 24.02.0
Update kirigami-addons-0.11.0.tar.xz to 1.0.1
Update itinerary-23.08.5.tar.xz to 24.02.0