### PR TITLE
Add QtKeychain dependency

### DIFF
--- a/org.kde.itinerary.json
+++ b/org.kde.itinerary.json
@@ -80,6 +80,65 @@
                 "/lib/pkgconfig"
             ]
         },
+{
+            "name": "qtkeychain",
+            "buildsystem": "cmake-ninja",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/frankosterfeld/qtkeychain/archive/0.14.2.tar.gz",
+                    "sha256": "cf2e972b783ba66334a79a30f6b3a1ea794a1dc574d6c3bebae5ffd2f0399571",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 4138,
+                        "stable-only": true,
+                        "url-template": "https://github.com/frankosterfeld/qtkeychain/archive/$version.tar.gz"
+                    }
+                }
+            ],
+            "config-opts": [
+                "-DCMAKE_INSTALL_LIBDIR=/app/lib",
+                "-DLIB_INSTALL_DIR=/app/lib",
+                "-DBUILD_TRANSLATIONS=NO",
+                "-DBUILD_WITH_QT6=ON"
+            ],
+            "cleanup": [
+                "/include",
+                "/lib/cmake",
+                "/mkspecs"
+            ],
+            "modules": [
+                {
+                    "name": "libsecret",
+                    "buildsystem": "meson",
+                    "config-opts": [
+                        "-Dmanpage=false",
+                        "-Dvapi=false",
+                        "-Dgtk_doc=false",
+                        "-Dintrospection=false",
+                        "-Dcrypto=disabled"
+                    ],
+                    "sources": [
+                        {
+                            "type": "archive",
+                            "url": "https://download.gnome.org/sources/libsecret/0.21/libsecret-0.21.4.tar.xz",
+                            "sha256": "163d08d783be6d4ab9a979ceb5a4fecbc1d9660d3c34168c581301cd53912b20",
+                            "x-checker-data": {
+                                "type": "anitya",
+                                "project-id": 13150,
+                                "stable-only": true,
+                                "url-template": "https://download.gnome.org/sources/libsecret/${version0}.${version1}/libsecret-$version.tar.xz"
+                            }
+                        }
+                    ],
+                    "cleanup": [
+                        "/bin/secret-tool",
+                        "/include",
+                        "/lib/pkgconfig"
+                    ]
+                }
+            ]
+        },
         {
             "name": "kpkpass",
             "config-opts": [


### PR DESCRIPTION
Needed with 24.08 directly, and indirectly already for the (optional) Matrix integration that is still missing here entirely.